### PR TITLE
Doc updates

### DIFF
--- a/annotationframeworkclient/annotationengine.py
+++ b/annotationframeworkclient/annotationengine.py
@@ -31,25 +31,26 @@ def AnnotationClient(server_address,
                      api_version='latest',
                      verify=True):
     """ Factory for returning AnnotationClient
-    Parameters
-    ----------
-    server_address : str 
-        server_address to use to connect to (i.e. https://minniev1.microns-daf.com)
-    datastack_name : str
-        Name of the datastack.
-    auth_client : AuthClient or None, optional
-        Authentication client to use to connect to server. If None, do not use authentication.
-    api_version : str or int (default: latest)
-        What version of the api to use, 0: Legacy client (i.e www.dynamicannotationframework.com) 
-        2: new api version, (i.e. minniev1.microns-daf.com)
-        'latest': default to the most recent (current 2)
-    verify : str (default : True)
-        whether to verify https
+    
+        Parameters
+        ----------
+        server_address : str 
+            server_address to use to connect to (i.e. https://minniev1.microns-daf.com)
+        datastack_name : str
+            Name of the datastack.
+        auth_client : AuthClient or None, optional
+            Authentication client to use to connect to server. If None, do not use authentication.
+        api_version : str or int (default: latest)
+            What version of the api to use, 0: Legacy client (i.e www.dynamicannotationframework.com) 
+            2: new api version, (i.e. minniev1.microns-daf.com)
+            'latest': default to the most recent (current 2)
+        verify : str (default : True)
+            whether to verify https
 
-    Returns
-    -------
-    ClientBaseWithDatastack
-        List of datastack names for available datastacks on the annotation engine
+        Returns
+        -------
+        ClientBaseWithDatastack
+            List of datastack names for available datastacks on the annotation engine
     """
 
     if auth_client is None:

--- a/annotationframeworkclient/chunkedgraph.py
+++ b/annotationframeworkclient/chunkedgraph.py
@@ -464,12 +464,12 @@ class ChunkedGraphClientV1(ClientBase):
     def is_latest_roots(self, root_ids, timestamp=None):
         """check whether these root_ids are still a root at this timestamp
 
-        Args:
-            root_ids ([type]): root ids to check
-            timestamp (datetime.dateime, optional): timestamp to check whether these IDs are valid root_ids. Defaults to None (assumes now).
-        Returns:
-        np.array[np.Boolean]
-            boolean array of whether these are valid root_ids
+            Args:
+                root_ids ([type]): root ids to check
+                timestamp (datetime.dateime, optional): timestamp to check whether these IDs are valid root_ids. Defaults to None (assumes now).
+            
+            Returns:
+                np.array[np.Boolean]: boolean array of whether these are valid root_ids
         """
         endpoint_mapping = self.default_url_mapping
         url = self._endpoints["is_latest_roots"].format_map(endpoint_mapping)

--- a/annotationframeworkclient/frameworkclient.py
+++ b/annotationframeworkclient/frameworkclient.py
@@ -44,8 +44,12 @@ class FrameworkClientGlobal(object):
 
     This client wraps all the other clients and keeps track of the things that need to be consistent across them.
     To instantiate a client:
-    client = FrameworkClient(datastack_name='my_datastack', server_address='www.myserver.com',
-                             auth_token_file='~/.mysecrets/secrets.json')
+
+    .. code:: python
+
+        client = FrameworkClient(datastack_name='my_datastack',
+                                 server_address='www.myserver.com',
+                                 auth_token_file='~/.mysecrets/secrets.json')
 
     Then
     * client.info is an InfoService client (see infoservice.InfoServiceClient)
@@ -177,8 +181,12 @@ class FrameworkClientFull(FrameworkClientGlobal):
 
     This client wraps all the other clients and keeps track of the things that need to be consistent across them.
     To instantiate a client:
-    client = FrameworkClient(datastack_name='my_datastack', server_address='www.myserver.com',
-                             auth_token_file='~/.mysecrets/secrets.json')
+    
+    .. code:: python
+
+        client = FrameworkClient(datastack_name='my_datastack',
+                                 server_address='www.myserver.com',
+                                 auth_token_file='~/.mysecrets/secrets.json')
 
     Then
     * client.info is an InfoService client (see infoservice.InfoServiceClient)

--- a/annotationframeworkclient/materializationengine.py
+++ b/annotationframeworkclient/materializationengine.py
@@ -242,8 +242,10 @@ class MaterializatonClientV2(ClientBase):
         endpoint_mapping["version"] = version
         url = self._endpoints["version_metadata"].format_map(endpoint_mapping)
         response = self.session.get(url, verify=self.verify)
-        self.raise_for_status(response)
-        return response.json()
+        d= handle_response(response)
+        d['time_stamp']=convert_timestamp(d['time_stamp'])
+        d['expires_on']=convert_timestamp(d['expires_on'])
+        return d
 
     def get_timestamp(self, version: int = None, datastack_name: str = None):
         """Get datetime.datetime timestamp for a materialization version.
@@ -262,7 +264,7 @@ class MaterializatonClientV2(ClientBase):
         """
         meta = self.get_version_metadata(
             version=version, datastack_name=datastack_name)
-        return datetime.strptime(meta['time_stamp'], '%Y-%m-%dT%H:%M:%S.%f')
+        return convert_timestamp(meta['time_stamp'])
 
     @cached(cache=TTLCache(maxsize=100, ttl=60*60*12))
     def get_versions_metadata(self, datastack_name=None):
@@ -280,7 +282,11 @@ class MaterializatonClientV2(ClientBase):
         endpoint_mapping["datastack_name"] = datastack_name
         url = self._endpoints["versions_metadata"].format_map(endpoint_mapping)
         response = self.session.get(url, verify=self.verify)
-        return handle_response(response)
+        d= handle_response(response)
+        for md in d:
+            md['time_stamp']=convert_timestamp(md['time_stamp'])
+            md['expires_on']=convert_timestamp(md['expires_on'])
+        return d
 
     def get_table_metadata(self, table_name: str, datastack_name=None):
         """ Get metadata about a table

--- a/annotationframeworkclient/materializationengine.py
+++ b/annotationframeworkclient/materializationengine.py
@@ -69,24 +69,26 @@ def MaterializationClient(server_address,
                           version=None,
                           verify=True):
     """ Factory for returning AnnotationClient
-    Parameters
-    ----------
-    server_address : str 
-        server_address to use to connect to (i.e. https://minniev1.microns-daf.com)
-    datastack_name : str
-        Name of the datastack.
-    auth_client : AuthClient or None, optional
-        Authentication client to use to connect to server. If None, do not use authentication.
-    api_version : str or int (default: latest)
-        What version of the api to use, 0: Legacy client (i.e www.dynamicannotationframework.com) 
-        2: new api version, (i.e. minniev1.microns-daf.com)
-        'latest': default to the most recent (current 2)
-    version : default version to query
-        if None will default to latest version
-    Returns
-    -------
-    ClientBaseWithDatastack
-        List of datastack names for available datastacks on the annotation engine
+        
+        Parameters
+        ----------
+        server_address : str 
+            server_address to use to connect to (i.e. https://minniev1.microns-daf.com)
+        datastack_name : str
+            Name of the datastack.
+        auth_client : AuthClient or None, optional
+            Authentication client to use to connect to server. If None, do not use authentication.
+        api_version : str or int (default: latest)
+            What version of the api to use, 0: Legacy client (i.e www.dynamicannotationframework.com) 
+            2: new api version, (i.e. minniev1.microns-daf.com)
+            'latest': default to the most recent (current 2)
+        version : default version to query
+            if None will default to latest version
+
+        Returns
+        -------
+        ClientBaseWithDatastack
+            List of datastack names for available datastacks on the annotation engine
     """
 
     if auth_client is None:
@@ -270,11 +272,11 @@ class MaterializatonClientV2(ClientBase):
     def get_versions_metadata(self, datastack_name=None):
         """get the metadata for all the versions that are presently available and valid
 
-        Args:
-            datastack_name (str, optional): datastack to query. If None, defaults to the value set in the client.
-        Returns:
-        list[dict]
-            a list of metadata dictionaries
+            Args:
+                datastack_name (str, optional): datastack to query. If None, defaults to the value set in the client.
+            
+            Returns:
+                list[dict]: a list of metadata dictionaries
         """
         if datastack_name is None:
             datastack_name = self.datastack_name
@@ -526,8 +528,9 @@ class MaterializatonClientV2(ClientBase):
                 default False, if False data is returned as one column with [x,y,z] array (slower)
             materialization_version (int, optional): version to query. 
                 If None defaults to one specified in client.
+        
         Returns:
-        pd.DataFrame: a pandas dataframe of results of query
+            pd.DataFrame: a pandas dataframe of results of query
 
         """
         if materialization_version is None:

--- a/annotationframeworkclient/materializationengine.py
+++ b/annotationframeworkclient/materializationengine.py
@@ -129,7 +129,7 @@ class MaterializatonClientV2(ClientBase):
 
     @property
     def homepage(self):
-        url = self._server_address + "/materialize/views/datastack/" + self._datastack_name
+        url = f"{self._server_address}/materialize/views/datastack/{self._datastack_name}"
         return HTML(f'<a href="{url}" target="_blank">Materialization Engine</a>')
         
     @version.setter

--- a/annotationframeworkclient/materializationengine.py
+++ b/annotationframeworkclient/materializationengine.py
@@ -709,7 +709,7 @@ class MaterializatonClientV2(ClientBase):
         materialization_version=None
         # make sure the materialization's are increasing in ID/time
         for md in sorted(mds, key=lambda x: x['id']):
-            ts = convert_timestamp(md['time_stamp'])
+            ts = md['time_stamp']
             if (timestamp > ts):
                 materialization_version=md['version']
                 timestamp_start = ts

--- a/docs/api/annotationframeworkclient.rst
+++ b/docs/api/annotationframeworkclient.rst
@@ -84,6 +84,15 @@ annotationframeworkclient.jsonservice module
    :undoc-members:
    :show-inheritance:
 
+annotationframeworkclient.materializationengine module
+------------------------------------------------------
+
+.. automodule:: annotationframeworkclient.materializationengine
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 Module contents
 ---------------
 

--- a/docs/guide/annotation.rst
+++ b/docs/guide/annotation.rst
@@ -65,3 +65,27 @@ The following could would create a new annotation and then upload it to the serv
                'pt': {'position': [1,2,3]},
                'func_id': 0}
    client.annotation.post_annotation(table_name='test_table', data=[new_data])
+
+There are methods to simplify annotation uploads if you have a pandas dataframe
+whose structure mirrors the struction of the annotation schema you want to upload
+
+.. code:: python
+
+    import pandas as pd
+
+    df = pd.DataFrame([{'id':0,
+             'type': 'microns_func_coreg',
+             'pt_position': [1,2,3]},
+             'func_id': 0}, 
+            {'id':1,
+            'type': 'microns_func_coreg',
+            'pt_position': [3,2,1]},
+            'func_id': 2}])
+    client.annotation.post_annotation_df('test_table', df)
+
+Note that here I specified the IDs of my annotations, which you can do, 
+but then its up to you to assure that the IDs don't collide with other IDs.
+If you leave them blank then the service will assign the IDs for you.
+
+There is a similar method for updating 
+:func:`annotationframeworkclient.annotationengine.AnnotationClientV2.update_annotation_df`

--- a/docs/guide/chunkedgraph.rst
+++ b/docs/guide/chunkedgraph.rst
@@ -14,7 +14,7 @@ Usually in Neuroglancer, one never notices supervoxel ids, but they are
 important for programmatic work. In order to look up the root id for a
 location in space, one needs to use the supervoxel segmentation to get
 the associated supervoxel id. The ChunkedGraph client makes this easy
-using the ``get_root_ids`` method.
+using the :func:`~annotationframeworkclient.chunkedgraph.ChunkedGraphClientV1.get_root_id` method.
 
 .. code:: python
 
@@ -38,11 +38,20 @@ different than it is now.
     sv_id = 104200755619042523
     client.chunkedgraph.get_root_id(supervoxel_id=sv_id, timestamp=timestamp)
 
+If you are doing this across lots of supervoxels (or any nodes)
+then you can do it more efficently in one request with
+:func:`~annotationframeworkclient.chunkedgraph.ChunkedGraphClientV1.get_roots`
+
+.. code:: python
+
+    node_ids = [104200755619042523, 104200755619042524,104200755619042525]
+    root_ids = client.chunkedgraph.get_roots(node_ids)
+
 Getting supervoxels for a root id
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A root id is associated with a particular agglomeration of supervoxels,
-which can be found with the ``get_leaves`` method. A new root id is
+which can be found with the :func:`~annotationframeworkclient.chunkedgraph.ChunkedGraphClientV1.get_leaves` method. A new root id is
 generated for every new change in the chunkedgraph, so time stamps do
 not apply.
 
@@ -50,3 +59,19 @@ not apply.
 
     root_id = 648518346349541252
     client.chunkedgraph.get_leaves(root_id)
+
+You can also query the chunkedgraph not all the way to the bottom, using the stop_layer
+option
+
+.. code:: python
+
+    root_id = 648518346349541252
+    client.chunkedgraph.get_leaves(root_id,stop_layer=2)
+
+This will get all the level 2 IDs for this root, which correspond to the lowest chunk of the heirachy.
+An analogous option exists for :func:`~annotationframeworkclient.chunkedgraph.ChunkedGraphClientV1.get_roots`.
+
+Other functions
+^^^^^^^^^^^^^^^
+
+There are a variety of other interesting functions to explore in the :class:`~annotationframeworkclient.chunkedgraph.ChunkedGraphClientV1`

--- a/docs/guide/materialization.rst
+++ b/docs/guide/materialization.rst
@@ -1,0 +1,185 @@
+Materialization
+================
+
+The Materialization client allows one to interact with the materialized
+annotation tables, that were posted to the annotation service (see 
+:doc:`annotation`). 
+
+To see the entire class visit the API doc :class:`~annotationframeworkclient.materializationengine.MaterializatonClientV2`
+
+The service regularly looks up all annotations and the segids underneath
+all the boundspatialpoints. You can then query these tables to find out
+the IDs that underlie the annotations, or the annotations that now intersect
+with certain IDs.
+
+For example, one common pattern is that you have idenfied a cell based on
+the location of its cell body, and you have an annotation there.
+
+You want to know what are the inputs onto the cell, so you first query the 
+annotation table with your soma annotation, asking for the current ID underneath
+that soma.  Then you query a synapse table for all synapse annotations that 
+have a post-synaptic ID equal to the ID from your soma annotation. 
+
+In this way your code stays the same, as the proofreading changes and you can
+track the connectivity of your cell over time.
+
+Initializing the client
+^^^^^^^^^^^^^^^^^^^^^^^
+By default when you initialize the overall client, it will choose the most recent
+materialization version available.  This may or may not be desirable depending on your
+use case.  If your code involves using specific IDs then you should be using a 
+specific version that is tied to a timepoint where those IDs are valid.
+
+To see what versions are available, use the :func:`~annotationframeworkclient.materializationengine.MaterializatonClientV2.get_versions`
+
+.. code:: python
+
+    client.materialize.get_versions()
+
+Each version has a timestamp it was run on as well as a date when it will expire.
+You can query all this metadata for a specific version  using 
+:func:`~annotationframeworkclient.materializationengine.MaterializatonClientV2.get_version_metadata`
+or all versions using
+:func:`~annotationframeworkclient.materializationengine.MaterializatonClientV2.get_versions_metadata`
+
+
+To change the default version, alter the .version property of the materialization client.
+
+.. code:: python
+
+    client.materialize.version = 9
+
+or specify the version when making a particular call.
+
+Browsing versions
+^^^^^^^^^^^^^^^^^
+To see what tables are available in a version you can use 
+:func:`~annotationframeworkclient.materializationengine.MaterializatonClientV2.get_tables`
+
+If you want to read about the description of what that table is, use the annotationengine client
+:func:`~annotationframeworkclient.annotationengine.AnnotationClientV2.get_table_metadata`
+
+If you want to read more about the schema for the annotation table use the schema service
+:func:`~annotationframeworkclient.emannotationschemas.SchemaClientLegacy.schema_definition`
+
+Note, the materialization service has a human readable webpage that links to the other services
+that might be more convienent for you to browse,
+to get a link there in ipython display ``client.materialize.homepage``
+
+for some important tables, the info service has a pointer to which table you should use in 
+the metadata for the datastack.  ```client.info.get_datastack_info()['synapse_table']```
+and ```client.info.get_datastack_info()['soma_table']```.
+
+To see how many annotations are in a particular table use
+
+.. code:: python
+
+    nannotations=client.materialize.get_annotation_count('my_table')
+
+Querying tables
+^^^^^^^^^^^^^^^
+To query a small table, you can just download the whole thing using  
+:func:`~annotationframeworkclient.materializationengine.MaterializatonClientV2.query_table`
+which will return a dataframe of the table.
+
+Note however, some tables, such as the synapse table might be very large 200-300 million rows
+and the service will only return the first 200,000 results.
+
+To just get a preview, use the limit argument
+
+.. code:: python
+
+    df=client.materialize.query_table('my_table', limit=10)
+
+For many applications, you will want to filter the query in some way.
+
+We offer three kinds of filters you can apply:  filter_equal, filter_in and filter_not_in. 
+For query_table each is specified as a dictionary where the keys are column names, 
+and the values are a list of values (or single value in the case of filter_equal). 
+
+So for example to query a synapse table for all synapses onto a neuron in flywire you would use
+
+.. code:: python
+
+    synapse_table = client.info.get_datastack_info('synapse_table')
+    df=client.materialize.query_table(synapse_table,
+                                      filter_equal_dict = {'post_pt_root_id': MYID})
+
+
+The speed of querying is affected by a number of factors, including the size of the data. 
+To improve the performance of results, you can reduce the number of columns returned using
+select_colums. 
+
+So for example, if you are only interested in the root_ids and locations of pre_synaptic terminals
+you might limit the query with select_columns.  Also, it is convient to return the 
+with positions as a column of np.array([x,y,z]) coordinates for many purposes.
+However, sometimes you might prefer to have them split out as seperate _x, _y, _z columns.
+To enable this option use split_columns=True.  Below is an example of using both options.
+
+.. code:: python
+
+    synapse_table = client.info.get_datastack_info('synapse_table')
+    df=client.materialize.query_table(synapse_table,
+                                      filter_equal_dict = {'post_pt_root_id': MYID},
+                                      select_columns=['id','pre_pt_root_id', 'pre_pt_position'],
+                                      split_columns=True)
+
+
+You can recombine split-out position columns using :func:`~annotationframeworkclient.materializationengine.concatenate_position_columns`
+
+
+Live Query
+^^^^^^^^^^
+In order to query the materialized tables above you can only use IDs that were present at the 
+timestamp of the materialization.  If you query the tables with an ID that is not valid during the 
+time of the materialization you will get empty results. 
+
+To check if root_ids are valid at your materialization's timestamp, you can use 
+:func:`~annotationframeworkclient.chunkedgraph.ChunkedGraphClientV1.is_latest_roots`
+
+.. code:: python
+
+    import numpy as np
+    mat_time = client.materialize.get_timestamp()
+    is_latest = client.chunkedgraph.is_latest_roots([MYID], timestamp=mat_time)
+    assert(np.all(is_latest))
+
+
+If you need to lookup what happened to that ID, you can use the chunkedgraph lineage tree,
+to look into the future or the past, depending on your application you can use
+:func:`~annotationframeworkclient.chunkedgraph.ChunkedGraphClientV1.get_lineage_graph`
+
+Again, the ideal situation is that you have an annotation in the database which refers 
+to your objects of interest, and querying that table by the id column will return the 
+object in the most recent materialization.
+
+However, sometimes you might be browsing and proofreadding the data and get an ID
+that is more recent that the most recent version available.  For convience, you can use 
+:func:`~annotationframeworkclient.materializationengine.MaterializatonClientV2.live_query`
+
+to automatically update the results of your query to a time in the future, such as now.
+For example, to pass now, use ```datetime.datetime.utcnow```.  Note all timestamps are in UTC
+throughout the codebase. 
+
+.. code:: python
+
+    import datetime
+    synapse_table = client.info.get_datastack_info('synapse_table')
+    df=client.materialize.live_query(synapse_table,
+                                      datetime.datetime.utcnow(),
+                                      filter_equal_dict = {'post_pt_root_id': MYID})
+
+This will raise an ValueError exception if the IDs passed in your filters are not valid at the timestamp given
+
+Note this is slower than querying a materialized version, so should you should only use this if necessary. 
+
+Also, keep in mind if you run multiple queries and at each time pass ``datetime.datetime.utcnow()``,
+there is no gauruntee that the IDs will be consistent from query to query, as proofreading might be happening
+at any time.  For larger scale analysis constraining oneself to a materialized version will ensure consistent results.
+
+Versions have varying expiration times in order to support the tradeoff between recency and consistency, 
+so before undertakin an analysis project consider what version you want to query and what your plan will be to 
+update your analysis to future versions. 
+
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Welcome to AnnotationFrameworkClient's documentation!
    guide/info
    guide/schemas
    guide/state
-
+   guide/materialization
 
 API
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyarrow>=3
 requests
 pandas
 cachetools>=4.2.1
+ipython


### PR DESCRIPTION
I did some updating of the documentation to include the materialization.  In the process I realized there were some features and changes that should make things easier and faster for the client. 

I added a 'homepage' property to materialization in order to let people browse things that way.

I moved the recombination of columns to the client side, because there were major speed improvements in serialization and deserialization when passing uniform numpy arrays over the wire.

I made all the metadata objects return datetime converting objects, rather than leaving that to the user. 

I also put in some example hyperlinks throughout the docs that bring the user to the function/class docstrings directly.   We should use these more broadly.