### PR TITLE
Endpoint + materialization timestamp

### DIFF
--- a/annotationframeworkclient/endpoints.py
+++ b/annotationframeworkclient/endpoints.py
@@ -1,4 +1,4 @@
-default_global_server_address = "https://globalv1.daf-apis.com"
+default_global_server_address = "https://global.daf-apis.com"
 
 # -------------------------------
 # ------ AnnotationEngine endpoints
@@ -41,9 +41,7 @@ materialization_endpoints_v2 = {
     "tables": mat_v2_api + "/datastack/{datastack_name}/version/{version}/tables",
     "metadata": mat_v2_api
     + "/datastack/{datastack_name}/version/{version}/table/{table_name}/metadata",
-    "versions_metadata": mat_v2_api
-    + "/datastack/{datastack_name}/metadata",
-    
+    "versions_metadata": mat_v2_api + "/datastack/{datastack_name}/metadata",
 }
 materialization_api_versions = {2: materialization_endpoints_v2}
 annotation_api_versions = {0: annotation_endpoints_legacy, 2: annotation_endpoints_v2}
@@ -116,7 +114,7 @@ chunkedgraph_endpoints_v1 = {
     "handle_lineage_graph": pcg_v1 + "/table/{table_id}/root/{root_id}/lineage_graph",
     "past_id_mapping": pcg_v1 + "/table/{table_id}/past_id_mapping",
     "operation_details": pcg_v1 + "/table/{table_id}/operation_details",
-    "is_latest_roots": pcg_v1 + "/table/{table_id}/is_latest_roots"
+    "is_latest_roots": pcg_v1 + "/table/{table_id}/is_latest_roots",
 }
 
 chunkedgraph_api_versions = {

--- a/annotationframeworkclient/materializationengine.py
+++ b/annotationframeworkclient/materializationengine.py
@@ -60,6 +60,8 @@ class MEEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 def convert_timestamp(ts):
+    if isinstance(ts, datetime):
+        return ts
     return datetime.strptime(ts, '%Y-%m-%dT%H:%M:%S.%f')
 
 def MaterializationClient(server_address,


### PR DESCRIPTION
Two fixes for the client that I needed to make it work with my existing workflows.

1) Update the default global endpoint to `global.daf-apis.com` (no v1)
2) Allow explicit `datetime.datetime` objects for materialization, not just the specific string format that the PyChunkedGraph uses.